### PR TITLE
Add HTTP error code explanation page

### DIFF
--- a/src/app/spec/errorcode/page.module.css
+++ b/src/app/spec/errorcode/page.module.css
@@ -1,0 +1,23 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  text-align: center;
+}
+
+.errorCode {
+  font-size: 4rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+}
+
+.explanation {
+  font-size: 1.5rem;
+}
+
+.noError {
+  font-size: 1.5rem;
+  color: red;
+}

--- a/src/app/spec/errorcode/page.tsx
+++ b/src/app/spec/errorcode/page.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from 'next/router';
+import styles from './page.module.css';
+
+const errorCodeExplanations = {
+  400: 'Bad Request: The server could not understand the request due to invalid syntax.',
+  401: 'Unauthorized: The client must authenticate itself to get the requested response.',
+  403: 'Forbidden: The client does not have access rights to the content.',
+  404: 'Not Found: The server can not find the requested resource.',
+  500: 'Internal Server Error: The server has encountered a situation it doesn\'t know how to handle.',
+  502: 'Bad Gateway: The server was acting as a gateway or proxy and received an invalid response from the upstream server.',
+  503: 'Service Unavailable: The server is not ready to handle the request.',
+  504: 'Gateway Timeout: The server is acting as a gateway or proxy and did not get a response in time from the upstream server.'
+};
+
+const ErrorCodePage = () => {
+  const router = useRouter();
+  const { hash } = router.asPath;
+  const errorCode = hash ? hash.substring(1) : null;
+  const explanation = errorCodeExplanations[errorCode];
+
+  return (
+    <div className={styles.container}>
+      {explanation ? (
+        <>
+          <h1 className={styles.errorCode}>{errorCode}</h1>
+          <p className={styles.explanation}>{explanation}</p>
+        </>
+      ) : (
+        <p className={styles.noError}>No error code specified or invalid error code.</p>
+      )}
+    </div>
+  );
+};
+
+export default ErrorCodePage;


### PR DESCRIPTION
Add a new page for displaying HTTP error code explanations.

* Create `src/app/spec/errorcode/page.tsx` to display HTTP error code explanations based on the URL hash.
* Define a mapping of HTTP error codes to their explanations.
* Add `src/app/spec/errorcode/page.module.css` for styling the error code explanation page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/1?shareId=997b518e-b04b-4087-b385-1f2a5a599c7a).