### PR TITLE
Fix error in errorcode page

### DIFF
--- a/src/app/spec/errorcode/page.tsx
+++ b/src/app/spec/errorcode/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 import styles from './page.module.css';
 


### PR DESCRIPTION
Add 'use client' directive to `src/app/spec/errorcode/page.tsx` to resolve import error for `useRouter`.

* Add 'use client' directive at the top of the file
* Fix import error for the component that needs `useRouter`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/3?shareId=44d6e5a1-56d7-4c7d-8eb1-242dde3a6a53).