### PR TITLE
Add release notes page

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
             <li><a href="/spec/database">Database Specification</a></li>
             <li><a href="/spec/log">Log Specification</a></li>
             <li><a href="/spec/middleware">Middleware Specification</a></li>
+            <li><a href="/release/{{version}}">Release Notes</a></li>
           </ul>
         </nav>
         {children}

--- a/src/app/release/[version]/page.tsx
+++ b/src/app/release/[version]/page.tsx
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const ReleaseNotes = () => {
+  const router = useRouter();
+  const { version } = router.query;
+  const [releaseNotes, setReleaseNotes] = useState(null);
+
+  useEffect(() => {
+    if (version) {
+      fetch(`/api/release-notes/${version}`)
+        .then((response) => response.json())
+        .then((data) => setReleaseNotes(data))
+        .catch((error) => console.error('Error fetching release notes:', error));
+    }
+  }, [version]);
+
+  if (!releaseNotes) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h1>Release Notes for Version {version}</h1>
+      <pre>{JSON.stringify(releaseNotes, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default ReleaseNotes;


### PR DESCRIPTION
Add a new page to display release notes for a specific version.

* **Release Notes Page**
  - Create `src/app/release/[version]/page.tsx` to display release notes for a specific version.
  - Use `useRouter` hook from `next/router` to get the `version` parameter from the URL.
  - Fetch release notes data based on the `version` parameter.
  - Render the release notes data in the component.

* **Navigation Link**
  - Add a new navigation link to the release notes page with the route `/release/{{version}}` in `src/app/layout.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/4?shareId=239abe3f-25a5-497b-bda6-9d5a108a0dea).