### PR TITLE
Add Install page with Maven dependency instructions

### DIFF
--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -1,0 +1,19 @@
+const Install = () => {
+  return (
+    <div>
+      <h1>Install SDK</h1>
+      <p>To add the Maven dependency for the SDK, add the following to your `pom.xml` file:</p>
+      <pre>
+        <code>
+          {`<dependency>
+  <groupId>com.phodal.sdk</groupId>
+  <artifactId>sdk</artifactId>
+  <version>1.0.0</version>
+</dependency>`}
+        </code>
+      </pre>
+    </div>
+  );
+};
+
+export default Install;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ export default function RootLayout({
             <li><a href="/spec/database">Database Specification</a></li>
             <li><a href="/spec/log">Log Specification</a></li>
             <li><a href="/spec/middleware">Middleware Specification</a></li>
+            <li><a href="/install">Install SDK</a></li>
           </ul>
         </nav>
         {children}


### PR DESCRIPTION
Add an Install page for the SDK and update the navigation menu.

* **Install Page**
  - Create a new `src/app/install/page.tsx` file.
  - Add instructions for adding the Maven dependency `com.phodal.sdk` to the `pom.xml` file.
  - Export the `Install` page component.

* **Navigation Menu**
  - Add a link to the Install page in the navigation menu in `src/app/layout.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/5?shareId=074a4cd3-fd5b-4db4-a31a-f667ac0de125).