### PR TITLE
Redesign layout using AntDesign

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import AntHeader from "../components/AntHeader";
+import AntSider from "../components/AntSider";
+import AntContent from "../components/AntContent";
+import AntdRegistry from "../components/AntdRegistry";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,16 +32,19 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <nav>
-          <ul>
-            <li><a href="/spec/database">Database Specification</a></li>
-            <li><a href="/spec/log">Log Specification</a></li>
-            <li><a href="/spec/middleware">Middleware Specification</a></li>
-            <li><a href="/install">Install SDK</a></li>
-            <li><a href="/faq">FAQ</a></li>
-          </ul>
-        </nav>
-        {children}
+        <AntdRegistry>
+          <AntHeader>
+            <ul>
+              <li><a href="/spec/database">Database Specification</a></li>
+              <li><a href="/spec/log">Log Specification</a></li>
+              <li><a href="/spec/middleware">Middleware Specification</a></li>
+              <li><a href="/install">Install SDK</a></li>
+              <li><a href="/faq">FAQ</a></li>
+            </ul>
+          </AntHeader>
+          <AntSider>Sider content here</AntSider>
+          <AntContent>{children}</AntContent>
+        </AntdRegistry>
       </body>
     </html>
   );

--- a/src/components/AntContent.tsx
+++ b/src/components/AntContent.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import Layout from "antd/lib/layout";
+import { ContentProps } from "antd/lib/layout";
+
+const Content = Layout.Content;
+
+export default function AntContent(props: ContentProps) {
+  return <Content {...props} />;
+}

--- a/src/components/AntHeader.tsx
+++ b/src/components/AntHeader.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import Layout from "antd/lib/layout";
+import { HeaderProps } from "antd/lib/layout";
+
+const Header = Layout.Header;
+
+export default function AntHeader(props: HeaderProps) {
+  return <Header {...props} />;
+}

--- a/src/components/AntSider.tsx
+++ b/src/components/AntSider.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import Layout from "antd/lib/layout";
+import { SiderProps } from "antd/lib/layout";
+
+const Sider = Layout.Sider;
+
+export default function AntSider(props: SiderProps) {
+  return <Sider {...props} />;
+}

--- a/src/components/AntdRegistry.tsx
+++ b/src/components/AntdRegistry.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { ConfigProvider } from "antd";
+
+export default function AntdRegistry(props) {
+  return <ConfigProvider {...props} />;
+}


### PR DESCRIPTION
Add AntDesign wrappers for Header, Sider, Content, and ConfigProvider, and update the layout to use these components.

* **AntHeader.tsx**
  - Create a new file for the AntDesign Header wrapper.
  - Import `Layout` from `antd/lib/layout`.
  - Define and export a functional component `AntHeader`.
  - Use `Layout.Header` inside the component.
  - Spread the props to `Layout.Header`.

* **AntSider.tsx**
  - Create a new file for the AntDesign Sider wrapper.
  - Import `Layout` from `antd/lib/layout`.
  - Define and export a functional component `AntSider`.
  - Use `Layout.Sider` inside the component.
  - Spread the props to `Layout.Sider`.

* **AntContent.tsx**
  - Create a new file for the AntDesign Content wrapper.
  - Import `Layout` from `antd/lib/layout`.
  - Define and export a functional component `AntContent`.
  - Use `Layout.Content` inside the component.
  - Spread the props to `Layout.Content`.

* **AntdRegistry.tsx**
  - Create a new file for the AntDesign Registry wrapper.
  - Import `ConfigProvider` from `antd`.
  - Define and export a functional component `AntdRegistry`.
  - Use `ConfigProvider` inside the component.
  - Spread the props to `ConfigProvider`.

* **layout.tsx**
  - Import `AntHeader`, `AntSider`, `AntContent`, and `AntdRegistry` from their respective files.
  - Replace `nav` with `AntHeader`.
  - Add `AntSider` and `AntContent` to the layout.
  - Wrap the layout with `AntdRegistry`.
  - Adjust the layout structure to use AntDesign components.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/7?shareId=e84ecbb4-caef-4d00-8743-b574dc1979df).