### PR TITLE
Redesign layout using AntDesign

### DIFF
--- a/src/app/AntContent.tsx
+++ b/src/app/AntContent.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { Layout } from "antd";
+
+const AntContent = (props: any) => {
+  return <Layout.Content {...props} />;
+};
+
+export default AntContent;

--- a/src/app/AntHeader.tsx
+++ b/src/app/AntHeader.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { Layout } from "antd";
+
+const AntHeader = (props: any) => {
+  return <Layout.Header {...props} />;
+};
+
+export default AntHeader;

--- a/src/app/AntSider.tsx
+++ b/src/app/AntSider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { Layout } from "antd";
+
+const AntSider = (props: any) => {
+  return <Layout.Sider {...props} />;
+};
+
+export default AntSider;

--- a/src/app/AntdRegistry.tsx
+++ b/src/app/AntdRegistry.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ConfigProvider } from "antd";
+
+const AntdRegistry = ({ children }: { children: React.ReactNode }) => {
+  return <ConfigProvider>{children}</ConfigProvider>;
+};
+
+export default AntdRegistry;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,11 @@
-    import type { Metadata } from "next";
+import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
+import { Layout } from "antd";
+import AntdRegistry from "@ant-design/nextjs-registry";
+import AntHeader from "./AntHeader";
+import AntSider from "./AntSider";
+import AntContent from "./AntContent";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -28,16 +33,27 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <nav>
-          <ul>
-            <li><a href="/spec/database">Database Specification</a></li>
-            <li><a href="/spec/log">Log Specification</a></li>
-            <li><a href="/spec/middleware">Middleware Specification</a></li>
-            <li><a href="/install">Install SDK</a></li>
-            <li><a href="/faq">FAQ</a></li>
-          </ul>
-        </nav>
-        {children}
+        <AntdRegistry>
+          <Layout style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+            <AntHeader style={{ display: "flex", alignItems: "center" }}>
+              Header
+            </AntHeader>
+            <Layout style={{ flex: 1, display: "flex", flexDirection: "row", overflow: "hidden" }}>
+              <AntSider width={240} style={{ overflow: "auto" }} />
+              <Layout
+                style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "auto" }}>
+                <AntContent
+                  style={{
+                    margin: 0,
+                    minHeight: 280,
+                  }}
+                >
+                  {children}
+                </AntContent>
+              </Layout>
+            </Layout>
+          </Layout>
+        </AntdRegistry>
       </body>
     </html>
   );


### PR DESCRIPTION
Redesign the project layout using AntDesign components and wrappers.

* **Layout Changes**
  - Import `Layout`, `Header`, `Sider`, and `Content` from `antd` in `src/app/layout.tsx`.
  - Import `AntdRegistry` from `@ant-design/nextjs-registry`.
  - Wrap the layout with `<AntdRegistry>`.
  - Replace the existing layout with the provided AntDesign layout.
  - Remove the existing `nav` element and replace it with AntDesign components.

* **Wrapper Components**
  - Add `src/app/AntdRegistry.tsx` to export a wrapper component for AntDesign using `ConfigProvider`.
  - Add `src/app/AntHeader.tsx` to export a wrapper component for AntDesign Header.
  - Add `src/app/AntSider.tsx` to export a wrapper component for AntDesign Sider.
  - Add `src/app/AntContent.tsx` to export a wrapper component for AntDesign Content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/8?shareId=edf270c1-5df8-4d78-a248-865e657884da).