### PR TITLE
Fix ESLint errors by replacing `any` type with specific types

### DIFF
--- a/src/app/AntContent.tsx
+++ b/src/app/AntContent.tsx
@@ -2,7 +2,7 @@
 
 import { Layout } from "antd";
 
-const AntContent = (props: any) => {
+const AntContent = (props: React.ComponentProps<typeof Layout.Content>) => {
   return <Layout.Content {...props} />;
 };
 

--- a/src/app/AntHeader.tsx
+++ b/src/app/AntHeader.tsx
@@ -2,7 +2,7 @@
 
 import { Layout } from "antd";
 
-const AntHeader = (props: any) => {
+const AntHeader = (props: React.ComponentProps<typeof Layout.Header>) => {
   return <Layout.Header {...props} />;
 };
 

--- a/src/app/AntSider.tsx
+++ b/src/app/AntSider.tsx
@@ -2,7 +2,7 @@
 
 import { Layout } from "antd";
 
-const AntSider = (props: any) => {
+const AntSider = (props: React.ComponentProps<typeof Layout.Sider>) => {
   return <Layout.Sider {...props} />;
 };
 


### PR DESCRIPTION
Update type definitions in AntContent, AntHeader, and AntSider components to resolve ESLint errors.

* Change `props` type in `src/app/AntContent.tsx` from `any` to `React.ComponentProps<typeof Layout.Content>`.
* Change `props` type in `src/app/AntHeader.tsx` from `any` to `React.ComponentProps<typeof Layout.Header>`.
* Change `props` type in `src/app/AntSider.tsx` from `any` to `React.ComponentProps<typeof Layout.Sider>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/9?shareId=4685f364-68f0-4980-be09-370ce34eb0cb).