### PR TITLE
Add menu to Sider using AntDesign

### DIFF
--- a/src/app/AntSider.tsx
+++ b/src/app/AntSider.tsx
@@ -1,9 +1,48 @@
 "use client";
 
-import { Layout } from "antd";
+import { Layout, Menu, MenuProps } from "antd";
+import {
+  DatabaseOutlined,
+  FileTextOutlined,
+  ApiOutlined,
+  DownloadOutlined,
+  QuestionCircleOutlined,
+} from "@ant-design/icons";
+
+const items: MenuProps["items"] = [
+  {
+    key: "database",
+    icon: <DatabaseOutlined />,
+    label: <a href="/spec/database">Database Specification</a>,
+  },
+  {
+    key: "log",
+    icon: <FileTextOutlined />,
+    label: <a href="/spec/log">Log Specification</a>,
+  },
+  {
+    key: "middleware",
+    icon: <ApiOutlined />,
+    label: <a href="/spec/middleware">Middleware Specification</a>,
+  },
+  {
+    key: "install",
+    icon: <DownloadOutlined />,
+    label: <a href="/install">Install SDK</a>,
+  },
+  {
+    key: "faq",
+    icon: <QuestionCircleOutlined />,
+    label: <a href="/faq">FAQ</a>,
+  },
+];
 
 const AntSider = (props: React.ComponentProps<typeof Layout.Sider>) => {
-  return <Layout.Sider {...props} />;
+  return (
+    <Layout.Sider {...props}>
+      <Menu items={items} />
+    </Layout.Sider>
+  );
 };
 
 export default AntSider;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({
               Header
             </AntHeader>
             <Layout style={{ flex: 1, display: "flex", flexDirection: "row", overflow: "hidden" }}>
-              <AntSider width={240} style={{ overflow: "auto" }} defaultSelectedKeys={[currentPath]} />
+              <AntSider width={240} style={{ overflow: "auto" }} />
               <Layout
                 style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "auto" }}>
                 <AntContent

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const currentPath = typeof window !== "undefined" ? window.location.pathname : "";
+
   return (
     <html lang="en">
       <body
@@ -39,7 +41,7 @@ export default function RootLayout({
               Header
             </AntHeader>
             <Layout style={{ flex: 1, display: "flex", flexDirection: "row", overflow: "hidden" }}>
-              <AntSider width={240} style={{ overflow: "auto" }} />
+              <AntSider width={240} style={{ overflow: "auto" }} defaultSelectedKeys={[currentPath]} />
               <Layout
                 style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "auto" }}>
                 <AntContent


### PR DESCRIPTION
Add AntDesign Menu with icons to `AntSider` component.

* **AntSider.tsx**
  - Import `Menu`, `MenuProps`, and various icons from `antd` and `@ant-design/icons`.
  - Define `items` array with menu items for Database, Log, Middleware, Install, and FAQ, each with corresponding icons.
  - Add `Menu` component inside `AntSider` component with `items` prop.

* **layout.tsx**
  - Add `defaultSelectedKeys` prop to `AntSider` with the current path.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/10?shareId=e88525ed-ffea-45be-bab4-58ee92a1815d).