### PR TITLE
Remove unused import statement in errorcode page

### DIFF
--- a/src/app/spec/errorcode/page.tsx
+++ b/src/app/spec/errorcode/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
 import styles from './page.module.css';
 import { Typography, List, Button, Card } from 'antd';
 


### PR DESCRIPTION
Remove the unused import statement for `usePathname` in `src/app/spec/errorcode/page.tsx`.

* Remove the `usePathname` import statement from the top of the file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/12?shareId=391f7499-d610-43a2-97f4-d04ec9bec6a8).