### PR TITLE
Modify header to display xx framework

### DIFF
--- a/src/app/AntHeader.tsx
+++ b/src/app/AntHeader.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { Layout } from "antd";
+import { Layout, Typography } from "antd";
 
 const AntHeader = (props: React.ComponentProps<typeof Layout.Header>) => {
-  return <Layout.Header {...props} />;
+  return (
+    <Layout.Header {...props}>
+      <Typography.Title level={2} style={{ color: 'white' }}>
+        xx framework
+      </Typography.Title>
+    </Layout.Header>
+  );
 };
 
 export default AntHeader;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import { Layout, Typography } from "antd";
+import { Layout } from "antd";
 import { AntdRegistry } from "@ant-design/nextjs-registry";
 import AntHeader from "./AntHeader";
 import AntSider from "./AntSider";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
-import { Layout } from "antd";
+import { Layout, Typography } from "antd";
 import { AntdRegistry } from "@ant-design/nextjs-registry";
 import AntHeader from "./AntHeader";
 import AntSider from "./AntSider";
@@ -35,9 +35,7 @@ export default function RootLayout({
       >
         <AntdRegistry>
           <Layout style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-            <AntHeader style={{ display: "flex", alignItems: "center" }}>
-              Header
-            </AntHeader>
+            <AntHeader style={{ display: "flex", alignItems: "center" }} />
             <Layout style={{ flex: 1, display: "flex", flexDirection: "row", overflow: "hidden" }}>
               <AntSider width={240} style={{ overflow: "auto" }} />
               <Layout


### PR DESCRIPTION
Update the header component to display the title "xx framework" and optimize the layout.

* **AntHeader.tsx**
  - Import `Typography` from "antd".
  - Modify `AntHeader` component to include a `Typography.Title` with the text "xx framework".

* **layout.tsx**
  - Import `Typography` from "antd".
  - Remove the "Header" text from the `AntHeader` component.
  - Adjust the layout to accommodate the updated `AntHeader` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/14?shareId=d6e0b3d5-3317-4962-ba86-45894b279b6d).