### PR TITLE
Add Protobuf specification page

### DIFF
--- a/src/app/AntSider.tsx
+++ b/src/app/AntSider.tsx
@@ -36,6 +36,16 @@ const items: MenuProps["items"] = [
     label: <a href="/spec/error-code">Error Code</a>,
   },
   {
+    key: "portobuf",
+    icon: <FileTextOutlined />,
+    label: <a href="/spec/portobuf">Portobuf</a>,
+  },
+  {
+    key: "protobuf",
+    icon: <FileTextOutlined />,
+    label: <a href="/spec/protobuf">Protobuf</a>,
+  },
+  {
     key: "faq",
     icon: <QuestionCircleOutlined />,
     label: <a href="/faq">FAQ</a>,

--- a/src/app/spec/portobuf/page.tsx
+++ b/src/app/spec/portobuf/page.tsx
@@ -1,0 +1,10 @@
+const PortobufSpecification = () => {
+  return (
+    <div>
+      <h1>Portobuf Specification</h1>
+      <p>This is the placeholder text for the Portobuf specification.</p>
+    </div>
+  );
+};
+
+export default PortobufSpecification;

--- a/src/app/spec/protobuf/page.tsx
+++ b/src/app/spec/protobuf/page.tsx
@@ -14,7 +14,7 @@ const ProtobufSpecification = () => {
       <p>Here is an example of a Protobuf schema definition:</p>
       <pre>
         <code>
-          {`syntax = "proto3";
+          {`syntax = &quot;proto3&quot;;
 
 message Person {
   string name = 1;
@@ -23,7 +23,7 @@ message Person {
 }`}
         </code>
       </pre>
-      <p>This schema defines a message type "Person" with three fields: name, id, and email. Each field has a type and a unique number.</p>
+      <p>This schema defines a message type &quot;Person&quot; with three fields: name, id, and email. Each field has a type and a unique number.</p>
     </div>
   );
 };

--- a/src/app/spec/protobuf/page.tsx
+++ b/src/app/spec/protobuf/page.tsx
@@ -1,0 +1,31 @@
+const ProtobufSpecification = () => {
+  return (
+    <div>
+      <h1>Protobuf Specification</h1>
+      <p>Protocol Buffers (Protobuf) is a method developed by Google for serializing structured data. It is useful in developing programs to communicate with each other over a network or for storing data. Protobuf is language-neutral, platform-neutral, and extensible, making it a popular choice for data serialization.</p>
+      <h2>Key Features</h2>
+      <ul>
+        <li>Language-neutral and platform-neutral</li>
+        <li>Efficient and fast serialization</li>
+        <li>Backward and forward compatibility</li>
+        <li>Extensible</li>
+      </ul>
+      <h2>Example</h2>
+      <p>Here is an example of a Protobuf schema definition:</p>
+      <pre>
+        <code>
+          {`syntax = "proto3";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+}`}
+        </code>
+      </pre>
+      <p>This schema defines a message type "Person" with three fields: name, id, and email. Each field has a type and a unique number.</p>
+    </div>
+  );
+};
+
+export default ProtobufSpecification;


### PR DESCRIPTION
Add Protobuf and Portobuf specification pages and update sidebar menu.

* **Add Protobuf Specification Page**
  - Create `src/app/spec/protobuf/page.tsx` with detailed Protobuf specification content.
  - Include key features and an example schema definition.

* **Add Portobuf Specification Page**
  - Create `src/app/spec/portobuf/page.tsx` with placeholder text for the Portobuf specification.

* **Update Sidebar Menu**
  - Modify `src/app/AntSider.tsx` to include new menu items for Protobuf and Portobuf specification pages.
  - Use `FileTextOutlined` icon for both new menu items.
  - Set `key` to "protobuf" and "portobuf" and `label` to links to `/spec/protobuf` and `/spec/portobuf` respectively.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/phodal/sdk-dx-example/pull/19?shareId=b21d8043-f570-41a5-b072-e2d4d6456dda).